### PR TITLE
Update Dockerfile to exclude README.md from project configuration copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install poetry
 RUN poetry config virtualenvs.create false
 
 # Copy project configuration
-COPY pyproject.toml poetry.lock README.md ./
+COPY pyproject.toml poetry.lock ./
 
 # Copy source code
 COPY app/ ./app/


### PR DESCRIPTION
- Removed README.md from the COPY command in the Dockerfile to streamline the build process and reduce image size.